### PR TITLE
Added missing label 'Textual format' from format_2330

### DIFF
--- a/dev/ontology/swo.owl
+++ b/dev/ontology/swo.owl
@@ -926,6 +926,7 @@ or of directed by the organization to do this.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://edamontology.org/format_2330">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000098"/>
+        <rdfs:label>Textual format</rdfs:label>
     </owl:Class>
     
 


### PR DESCRIPTION
Whilst reviewing this ontology I noticed that a plain text format was missing from the "data format specification" hierarchy. Upon further inspection, format_2330 imported from the EDAM ontology is "Textual format", and is just missing the label.
My commit adds the label from EDAM to make it consistent with the other data formats that have been imported.